### PR TITLE
Remove $LD_LIBRARY_PATH variable from LD_LIBRARY_PATH definition.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ architectures:
 apps:
   opentoonz-morevna:
     environment:
-      LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
+      LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
       HOME: "$SNAP_USER_COMMON"
       DISABLE_WAYLAND: 1
     command: desktop-launch $SNAP/bin/opentoonz


### PR DESCRIPTION
$LD_LIBRARY_PATH starts as null and thus leaves a trailing colon.
An extra colon will be added in a later invocation of snapcraft_runner,
and will result in the current working directory being searched by ld.

(See my comments at https://forum.snapcraft.io/t/ann-snapcraft-4-4-4-library-injection-vulnerability-on-built-snaps/21465/5?u=james-carroll )